### PR TITLE
IT-783/instance maintenance

### DIFF
--- a/templates/gitlab-runner.yaml
+++ b/templates/gitlab-runner.yaml
@@ -86,6 +86,7 @@ Resources:
             Principal:
               Service:
                 - ec2.amazonaws.com
+                - ssm.amazonaws.com
             Action:
               - 'sts:AssumeRole'
       Path: /
@@ -118,6 +119,11 @@ Resources:
               'Fn::Sub': '${AWS::Region}-iatlasdb-${Environment}-DBAccessSecurityGroup'
           SubnetId: !ImportValue
             'Fn::Sub': '${AWS::Region}-${VpcName}-${VpcSubnet}'
+      Tags:
+        - Key: "ManagedInstanceMaintenanceTarget"
+          Value: "yes"
+        - Key: "PatchGroup"
+          Value: "prod-default"
 Outputs:
   RunnerEc2InstanceId:
     Value: !Ref RunnerEc2Instance


### PR DESCRIPTION
This PR adds a policy to the instance profile that allows the SSM service to attach to the agent on the instance. 
