### PR TITLE
Remove unneeded sceptre param

### DIFF
--- a/config/prod/iatlas-db.yaml
+++ b/config/prod/iatlas-db.yaml
@@ -13,6 +13,5 @@ parameters:
   MasterUsername: !ssm /iatlas/prod/AuroraUsername
   MasterUserPassword: !ssm /iatlas/prod/AuroraPassword
   DBInstanceClass: "db.t3.large"
-  DBEngine: aurora-postgresql
   DBEngineVersion: 3.2.1 #compat with PostgreSQL 11.7
   DBPort: "5432"

--- a/config/staging/iatlas-db.yaml
+++ b/config/staging/iatlas-db.yaml
@@ -13,6 +13,5 @@ parameters:
   MasterUsername: !ssm /iatlas/staging/AuroraUsername
   MasterUserPassword: !ssm /iatlas/staging/AuroraPassword
   DBInstanceClass: "db.t3.large"
-  DBEngine: aurora-postgresql
   DBEngineVersion: 3.2.1 #compat with PostgreSQL 11.7
   DBPort: "5432"


### PR DESCRIPTION
Sceptre errors because I ended up not using the DBEngine parameter, but hardcoded it.
