### PR TITLE
Re-synch database versions

### DIFF
--- a/config/prod/iatlas-db.yaml
+++ b/config/prod/iatlas-db.yaml
@@ -9,9 +9,9 @@ stack_tags:
   OwnerEmail: "andrew.lamb@sagebase.org"
 parameters:
   VpcName: iatlasvpc
-  KmsKeyName: "/alias/iatlas-kms-prod/KmsKey"
+  KmsKeyName: !stack_output_external iatlas-kms-prod::KmsKeyArn
   MasterUsername: !ssm /iatlas/prod/AuroraUsername
   MasterUserPassword: !ssm /iatlas/prod/AuroraPassword
   DBInstanceClass: "db.t3.large"
-  DBEngineVersion: 3.2.2 #compat with PostgreSQL 11.7
+  DBEngineVersion: "11.7"
   DBPort: "5432"

--- a/config/prod/iatlas-db.yaml
+++ b/config/prod/iatlas-db.yaml
@@ -9,7 +9,7 @@ stack_tags:
   OwnerEmail: "andrew.lamb@sagebase.org"
 parameters:
   VpcName: iatlasvpc
-  KmsKeyName: !stack_output_external iatlas-kms-prod::KmsKeyArn
+  KmsKeyName: !stack_output_external iatlas-kms-prod::KmsKey
   MasterUsername: !ssm /iatlas/prod/AuroraUsername
   MasterUserPassword: !ssm /iatlas/prod/AuroraPassword
   DBInstanceClass: "db.t3.large"

--- a/config/prod/iatlas-db.yaml
+++ b/config/prod/iatlas-db.yaml
@@ -13,5 +13,5 @@ parameters:
   MasterUsername: !ssm /iatlas/prod/AuroraUsername
   MasterUserPassword: !ssm /iatlas/prod/AuroraPassword
   DBInstanceClass: "db.t3.large"
-  DBEngineVersion: 3.2.1 #compat with PostgreSQL 11.7
+  DBEngineVersion: 3.2.2 #compat with PostgreSQL 11.7
   DBPort: "5432"

--- a/config/staging/iatlas-db.yaml
+++ b/config/staging/iatlas-db.yaml
@@ -9,7 +9,7 @@ stack_tags:
   OwnerEmail: "andrew.lamb@sagebase.org"
 parameters:
   VpcName: iatlasvpc
-  KmsKeyName: !stack_output_external iatlas-kms-staging::KmsKeyArn
+  KmsKeyName: !stack_output_external iatlas-kms-staging::KmsKey
   MasterUsername: !ssm /iatlas/staging/AuroraUsername
   MasterUserPassword: !ssm /iatlas/staging/AuroraPassword
   DBInstanceClass: "db.t3.large"

--- a/config/staging/iatlas-db.yaml
+++ b/config/staging/iatlas-db.yaml
@@ -9,9 +9,9 @@ stack_tags:
   OwnerEmail: "andrew.lamb@sagebase.org"
 parameters:
   VpcName: iatlasvpc
-  KmsKeyName: "/alias/iatlas-kms-staging/KmsKey"
+  KmsKeyName: !stack_output_external iatlas-kms-staging::KmsKeyArn
   MasterUsername: !ssm /iatlas/staging/AuroraUsername
   MasterUserPassword: !ssm /iatlas/staging/AuroraPassword
   DBInstanceClass: "db.t3.large"
-  DBEngineVersion: 3.2.2 #compat with PostgreSQL 11.7
+  DBEngineVersion: "11.7"
   DBPort: "5432"

--- a/config/staging/iatlas-db.yaml
+++ b/config/staging/iatlas-db.yaml
@@ -13,5 +13,5 @@ parameters:
   MasterUsername: !ssm /iatlas/staging/AuroraUsername
   MasterUserPassword: !ssm /iatlas/staging/AuroraPassword
   DBInstanceClass: "db.t3.large"
-  DBEngineVersion: 3.2.1 #compat with PostgreSQL 11.7
+  DBEngineVersion: 3.2.2 #compat with PostgreSQL 11.7
   DBPort: "5432"

--- a/templates/aurora-postgresql-db.yaml
+++ b/templates/aurora-postgresql-db.yaml
@@ -37,8 +37,8 @@ Parameters:
     Description: 'Database engine version'
     Type: String
     AllowedValues:
-      - 3.2.1
-      - 3.2.2
+      - 11.7
+      - 11.6
   DBPort:
     Description: TCP/IP Port for the Database Instance
     Type: Number
@@ -152,7 +152,7 @@ Resources:
       EngineVersion: !Ref DBEngineVersion
       AutoMinorVersionUpgrade: true
       PerformanceInsightsKMSKeyId: !Ref KmsKeyName
-      PerformanceInsightsRetentionPeriod: 365
+      PerformanceInsightsRetentionPeriod: 7
       PubliclyAccessible: false
       EnablePerformanceInsights: true
       DBInstanceClass: !Ref DBInstanceClass
@@ -161,15 +161,15 @@ Outputs:
   ClusterEndpoint:
     Value: !GetAtt DBCluster.Endpoint.Address
     Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-ClusterEndpoint.Address'
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ClusterEndpointAddress'
   ClusterReadEndpoint:
     Value: !GetAtt DBCluster.ReadEndpoint.Address
     Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-ClusterReadEndpoint.Address'
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ClusterReadEndpointAddress'
   ClusterPort:
     Value: !GetAtt DBCluster.Endpoint.Port
     Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-ClusterEndpoint.Port'
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ClusterEndpointPort'
   InstanceId:
     Value: !Ref DBInstance
     Export:

--- a/templates/aurora-postgresql-db.yaml
+++ b/templates/aurora-postgresql-db.yaml
@@ -37,12 +37,8 @@ Parameters:
     Description: 'Database engine version'
     Type: String
     AllowedValues:
-      - 10.7
-      - 10.11
-      - 10.12
-      - 11.4
-      - 11.6
-      - 11.7
+      - 3.2.1
+      - 3.2.2
   DBPort:
     Description: TCP/IP Port for the Database Instance
     Type: Number

--- a/templates/gitlab-runner.yaml
+++ b/templates/gitlab-runner.yaml
@@ -92,9 +92,10 @@ Resources:
       Path: /
       ManagedPolicyArns:
         - !ImportValue
-          'Fn::Sub': '${AWS::Region}-essentials-ManagedInstanceRoleArn'
+          'Fn::Sub': '${AWS::Region}-essentials-TagRootVolumePolicy'
         - !Ref SsmManagedPolicy
         - !Ref KmsDecryptManagedPolicy
+        - 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore'
 
   RunnerInstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'

--- a/templates/kms.yaml
+++ b/templates/kms.yaml
@@ -66,7 +66,6 @@ Resources:
           - !Ref AWS::StackName
           - '/KmsKey'
       TargetKeyId: !Ref KmsKey
-
 Outputs:
   KmsKey:
     Value: !Ref KmsKey


### PR DESCRIPTION
The database versions were out of synch between postgres and aurora version strings. This bumps the version the latest aurora patch release as well.