### PR TITLE
Adding back network attachments with proper peering

### DIFF
--- a/config/common/peer-vpn-iatlasvpc.yaml
+++ b/config/common/peer-vpn-iatlasvpc.yaml
@@ -4,9 +4,9 @@ dependencies:
   - common/iatlasvpc.yaml
 parameters:
   PeeringConnectionId: pcx-0f97213011da78981
-  VpcPrivateRouteTable: rtb-073c34d41ecd890b1
-  VpcPublicRouteTable: rtb-0455bfa65d209db45
-  VpnCidr: 10.1.0.0/16
+  VpcPrivateRouteTable: !stack_output_external iatlasvpc::PrivateRouteTable
+  VpcPublicRouteTable: !stack_output_external iatlasvpc::PublicRouteTable
+  VpnCidr: !stack_output_external iatlasvpc::VpnCidr
 hooks:
   before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/peer-route-config.yaml --create-dirs -o templates/remote/peer-route-config.yaml"

--- a/config/common/peer-vpn-iatlasvpc.yaml
+++ b/config/common/peer-vpn-iatlasvpc.yaml
@@ -4,8 +4,8 @@ dependencies:
   - common/iatlasvpc.yaml
 parameters:
   PeeringConnectionId: pcx-0f97213011da78981
-  VpcPrivateRouteTable: rtb-03749e8c822352561
-  VpcPublicRouteTable: rtb-0707730d3016e2737
+  VpcPrivateRouteTable: rtb-073c34d41ecd890b1
+  VpcPublicRouteTable: rtb-0455bfa65d209db45
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:

--- a/config/common/peer-vpn-iatlasvpc.yaml
+++ b/config/common/peer-vpn-iatlasvpc.yaml
@@ -1,0 +1,12 @@
+template_path: remote/peer-route-config.yaml
+stack_name: peer-vpn-iatlasvpc
+dependencies:
+  - common/iatlasvpc.yaml
+parameters:
+  PeeringConnectionId: pcx-0f97213011da78981
+  VpcPrivateRouteTable: rtb-03749e8c822352561
+  VpcPublicRouteTable: rtb-0707730d3016e2737
+  VpnCidr: 10.1.0.0/16
+hooks:
+  before_launch:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/peer-route-config.yaml --create-dirs -o templates/remote/peer-route-config.yaml"

--- a/config/common/sage-tgw-iatlasvpc.yaml
+++ b/config/common/sage-tgw-iatlasvpc.yaml
@@ -1,0 +1,10 @@
+template_path: "remote/transit-gateway-attachment.yaml"
+stack_name: "sage-tgw-iatlasvpc"
+dependencies:
+  - common/iatlas-vpc.yaml
+parameters:
+  VpcName: "iatlasvpc"
+  TransitGatewayId: 'tgw-08aa3c487e457374a'   # sage-tgw transit gateway
+hooks:
+  before_launch:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/transit-gateway-attachment.yaml --create-dirs -o templates/remote/transit-gateway-attachment.yaml"


### PR DESCRIPTION
We had removed the VPC peering at an earlier stage. This adds the stacks back and uses the proper values for making a peering request to admincentral.
