### PR TITLE
Change dependency name in tgw template

### DIFF
--- a/config/common/sage-tgw-iatlasvpc.yaml
+++ b/config/common/sage-tgw-iatlasvpc.yaml
@@ -1,7 +1,7 @@
 template_path: "remote/transit-gateway-attachment.yaml"
 stack_name: "sage-tgw-iatlasvpc"
 dependencies:
-  - common/iatlas-vpc.yaml
+  - common/iatlasvpc.yaml
 parameters:
   VpcName: "iatlasvpc"
   TransitGatewayId: 'tgw-08aa3c487e457374a'   # sage-tgw transit gateway


### PR DESCRIPTION
This fixes a broken dependency name in a sceptre deployment config script.