### PR TITLE
Add exisiting keys to runner instances

### DIFF
--- a/config/prod/iatlas-runner.yaml
+++ b/config/prod/iatlas-runner.yaml
@@ -14,3 +14,4 @@ parameters:
   VpcSubnet: PrivateSubnet
   AMIId: ami-0810a318c4b1243c5 #AWS Linux from https://ami.sageit.org
   Environment: prod
+  KeyName: "iatlas-gitlab-runner-prod"

--- a/config/staging/iatlas-runner.yaml
+++ b/config/staging/iatlas-runner.yaml
@@ -14,3 +14,4 @@ parameters:
   VpcSubnet: PrivateSubnet
   AMIId: ami-0810a318c4b1243c5 #AWS Linux from https://ami.sageit.org
   Environment: staging
+  KeyName: "iatlas-gitlab-runner-staging"

--- a/templates/gitlab-runner.yaml
+++ b/templates/gitlab-runner.yaml
@@ -2,6 +2,10 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: >-
   A worker host for a GitLab runner connected to Jumpcloud
 Parameters:
+  KeyName:
+    Description: Name of an existing EC2 KeyPair to enable SSH access to the instance
+    Type: 'AWS::EC2::KeyPair::KeyName'
+    ConstraintDescription: must be the name of an existing EC2 KeyPair.
   InstanceType:
     Description: WebServer EC2 instance type
     Type: String
@@ -109,6 +113,7 @@ Resources:
     Properties:
       ImageId: !Ref AMIId
       InstanceType: !Ref InstanceType
+      KeyName: !Ref KeyName
       IamInstanceProfile: !Ref RunnerInstanceProfile
       NetworkInterfaces:
         - DeleteOnTermination: true


### PR DESCRIPTION
This adds an ssh keypair to the runner instance. The keypair is for shell access to maintain the builds. This PR passes pre-commit.