### PR TITLE
Initial version of iAtlas API deployment using Elastic Beanstalk

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,23 @@ The GitLab runner is an EC2 instance that can use the KMS key connected to its e
 to read secrets from the parameter store and interact with the Aurora cluster.
 
 [architecture]: infra-arch.svg "iAtlas architecture"
+
+## API Deployment
+
+The API is a Docker container built in Gitlab CI, so the deployment via Elastic Beanstalk requires two files:
+
+- The `Dockerrun.aws.json` file that specifies the application parameters to Docker
+- The `iatlas-[staging|production]-dockercfg` file that tells Docker how to authenticate against the Gitlab container registry
+
+These need to live in an S3 bucket, typically with a key prefix of the environment name (e.g. `staging/Dockerrun.aws.json`) and have ACLs on them that allow Elastic Beanstalk to read them. Examples of these files are available in the [iAtlas-API](https://gitlab.com/cri-iatlas/iatlas-api) repo.
+
+This also assumes that a secret exists in SecretsManager that contains the RDS creds for a non-root user for the application to use. CloudFormation can't manipulate user accounts in RDS, so this needs to be done manually:
+
+```sql
+CREATE USER iatlas_api WITH PASSWORD '<yourcomplexpasswordhere>';
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO iatlas_api;
+```
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -37,7 +37,3 @@ This also assumes that a secret exists in SecretsManager that contains the RDS c
 CREATE USER iatlas_api WITH PASSWORD '<yourcomplexpasswordhere>';
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO iatlas_api;
 ```
-
-
-
-

--- a/config/staging/iatlas-beanstalk-api.yaml
+++ b/config/staging/iatlas-beanstalk-api.yaml
@@ -1,0 +1,16 @@
+template_path: ebs-iatlas-api.yaml
+stack_name: ebs-iatlas-api-staging
+# dependencies:
+#   - common/iatlasvpc.yaml
+stack_tags:
+  Department: "CompOnc"
+  Project: "iAtlas"
+  OwnerEmail: "andrew.lamb@sagebase.org"
+parameters:
+  VpcId: vpc-0adeed12976b679eb
+  Subnets: subnet-074d70c8a084d765f,subnet-0e978d6bebda35338
+  Environment: staging
+  S3Bucket: elasticbeanstalk-us-west-2-556856096938
+  S3Key: staging/Dockerrun.aws.json
+    HostKeyName: sage-iatlas-ubuntu
+    FlaskEnvironment: staging

--- a/config/staging/iatlas-beanstalk-api.yaml
+++ b/config/staging/iatlas-beanstalk-api.yaml
@@ -1,7 +1,7 @@
-template_path: ebs-iatlas-api.yaml
+template_path: beanstalk-docker.yaml
 stack_name: ebs-iatlas-api-staging
-# dependencies:
-#   - common/iatlasvpc.yaml
+dependencies:
+  - common/iatlasvpc.yaml
 stack_tags:
   Department: "CompOnc"
   Project: "iAtlas"
@@ -12,5 +12,5 @@ parameters:
   Environment: staging
   S3Bucket: elasticbeanstalk-us-west-2-556856096938
   S3Key: staging/Dockerrun.aws.json
-    HostKeyName: sage-iatlas-ubuntu
-    FlaskEnvironment: staging
+  HostKeyName: sage-iatlas-ubuntu
+  FlaskEnvironment: staging

--- a/templates/beanstalk-docker.yaml
+++ b/templates/beanstalk-docker.yaml
@@ -20,7 +20,7 @@
       FlaskEnvironment:
           Type: String
           Description: The Flask configuration key to pass to the app
-          ConstraintDescription: Acceptable keys for Flask configuration 
+          ConstraintDescription: Acceptable keys for Flask configuration
           AllowedValues:
             - staging
             - production
@@ -29,14 +29,19 @@
         Type: AWS::ElasticBeanstalk::Application
         Properties:
           Description: iAtlas API Deployment
-          ApplicationVersions:
-          - VersionLabel: Initial Version
-            Description: Version 1.0
-            SourceBundle:
-              S3Bucket:
-                Ref: S3Bucket
-              S3Key:
-                Ref: S3Key
+
+      iAtlasApiVersion:
+        Type: AWS::ElasticBeanstalk::ApplicationVersion
+        Properties:
+          ApplicationName:
+            Ref: "iAtlasApiTest"
+          Description: Latest version
+          SourceBundle:
+            S3Bucket:
+              Ref: S3Bucket
+            S3Key:
+              Ref: S3Key
+
       iAtlasTest:
         Type: AWS::ElasticBeanstalk::Environment
         Properties:
@@ -87,4 +92,3 @@
               - iAtlasTest
               - EndpointURL
             - /graphiql
-    

--- a/templates/beanstalk-docker.yaml
+++ b/templates/beanstalk-docker.yaml
@@ -1,0 +1,90 @@
+---
+    AWSTemplateFormatVersion: '2010-09-09'
+    Description: AWS CloudFormation iAtlas API Test
+    Parameters:
+      Subnets:
+        Type: CommaDelimitedList
+        Description: Subnets
+      VpcId:
+        Type: String
+        Description: VPC Id
+      S3Bucket:
+        Type: String
+        Description: S3 Bucket name
+      S3Key:
+        Type: String
+        Description: S3 Key name
+      HostKeyName:
+        Type: String
+        Description: The host SSH key to assign to instances
+      FlaskEnvironment:
+          Type: String
+          Description: The Flask configuration key to pass to the app
+          ConstraintDescription: Acceptable keys for Flask configuration 
+          AllowedValues:
+            - staging
+            - production
+    Resources:
+      iAtlasApiTest:
+        Type: AWS::ElasticBeanstalk::Application
+        Properties:
+          Description: iAtlas API Deployment
+          ApplicationVersions:
+          - VersionLabel: Initial Version
+            Description: Version 1.0
+            SourceBundle:
+              S3Bucket:
+                Ref: S3Bucket
+              S3Key:
+                Ref: S3Key
+      iAtlasTest:
+        Type: AWS::ElasticBeanstalk::Environment
+        Properties:
+          ApplicationName:
+            Ref: iAtlasApiTest
+          Description: iAtlas API Environment
+          SolutionStackName: 64bit Amazon Linux 2 v3.1.2 running Docker
+          VersionLabel: Initial Version
+          OptionSettings:
+          - Namespace: aws:ec2:vpc
+            OptionName: VPCId
+            Value: !Ref VpcId
+          - Namespace: aws:ec2:vpc
+            OptionName: Subnets
+            Value: !Ref Subnets
+          - Namespace: aws:autoscaling:launchconfiguration
+            OptionName: InstanceType
+            Value: t3a.small
+          - Namespace: aws:autoscaling:launchconfiguration
+            OptionName: IamInstanceProfile
+            Value: aws-elasticbeanstalk-ec2-role
+          - Namespace: aws:autoscaling:launchconfiguration
+            OptionName: EC2KeyName
+            Value: !Ref HostKeyName
+          - Namespace: aws:elasticbeanstalk:application:environment
+            OptionName: FLASK_ENV
+            Value: !Ref FlaskEnvironment
+          - Namespace: aws:elasticbeanstalk:application:environment
+            OptionName: POSTGRES_DB
+            Value: '{{resolve:secretsmanager:staging/RDS/iatlas_api_creds:SecretString:dbname}}'
+          - Namespace: aws:elasticbeanstalk:application:environment
+            OptionName: POSTGRES_HOST
+            Value: '{{resolve:secretsmanager:staging/RDS/iatlas_api_creds:SecretString:host}}'
+          - Namespace: aws:elasticbeanstalk:application:environment
+            OptionName: POSTGRES_USER
+            Value: '{{resolve:secretsmanager:staging/RDS/iatlas_api_creds:SecretString:username}}'
+          - Namespace: aws:elasticbeanstalk:application:environment
+            OptionName: POSTGRES_PASSWORD
+            Value: '{{resolve:secretsmanager:staging/RDS/iatlas_api_creds:SecretString:password}}'
+    Outputs:
+      URL:
+        Description: The URL of the Elastic Beanstalk environment
+        Value:
+          Fn::Join:
+          - ''
+          - - http://
+            - Fn::GetAtt:
+              - iAtlasTest
+              - EndpointURL
+            - /graphiql
+    


### PR DESCRIPTION
PR Checklist:
This adds a CF template and staging parameters that will build an Elastic Beanstalk environment that runs the iAtlas-API using Docker. Because I do not have access to most of the supporting resources, I assume there will be a request from Sage to fill in the following:

- There is no WAF/ALB in front of the deployment. I don't currently have a reference for how Sage likes this done, but am perfectly happy to add it
- The DB creds in Secrets Manager are manually created. If Sage has a preference on this, I'm happy to add it to the code
- The current template doesn't constrain the possible values for subnets to deploy to. Related to ALB/WAF configuration.
