### PR TITLE
Update VPC template reference

### DIFF
--- a/config/common/iatlasvpc.yaml
+++ b/config/common/iatlasvpc.yaml
@@ -9,4 +9,4 @@ parameters:
   VpcName: iatlasvpc
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc-mini.yaml --create-dirs -o templates/remote/vpc-mini.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/VPC/vpc-mini.yaml --create-dirs -o templates/remote/vpc-mini.yaml"


### PR DESCRIPTION
The 'vpc-mini.yaml' template was moved in aws-infra repo[1].  Update
reference to new location.

[1] https://github.com/Sage-Bionetworks/aws-infra/blob/master/templates/VPC/vpc-mini.yaml