### PR TITLE
Setup service user/role

### DIFF
--- a/config/common/ci-access.yaml
+++ b/config/common/ci-access.yaml
@@ -6,4 +6,4 @@ parameters:
     - arn:aws:iam::aws:policy/AdministratorAccess
 hooks:
   before_launch:
-   - !cmd "wget https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/IAM/service-account.yaml -N -P templates/remote"
+   - !cmd "wget https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/IAM/service-account.yaml -N -P templates/remote"

--- a/config/common/ci-access.yaml
+++ b/config/common/ci-access.yaml
@@ -1,0 +1,9 @@
+# Setup a service account for CI to deploy CFN templates
+template_path: remote/service-account.yaml
+stack_name: ci-access
+parameters:
+  ManagedPolicyArns:
+    - arn:aws:iam::aws:policy/AdministratorAccess
+hooks:
+  before_launch:
+   - !cmd "wget https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/IAM/service-account.yaml -N -P templates/remote"

--- a/config/common/iatlasvpc.yaml
+++ b/config/common/iatlasvpc.yaml
@@ -1,5 +1,7 @@
 template_path: remote/vpc-mini.yaml
 stack_name: iatlasvpc
+dependencies:
+  - common/ci-access.yaml
 stack_tags:
   Department: "CompOnc"
   Project: "iAtlas"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,6 +1,5 @@
 project_code: "sage-bionetworks"
 profile: {{ var.profile | default("default") }}
 region: {{ var.region | default("us-east-1") }}
-template_bucket_name: "bootstrap-awss3cloudformationbucket-114n2ojlbvj21"
 template_key_prefix: {{ environment_variable.TRAVIS_BRANCH | default("testing") }}
 admincentral_cf_bucket: "bootstrap-awss3cloudformationbucket-19qromfd235z9"


### PR DESCRIPTION
This is to setup a AWS service user/role to deploy CFN templates to
the iAtlas AWS account.