### PR TITLE
refactor for new account

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,6 +1,6 @@
 project_code: "sage-bionetworks"
 profile: {{ var.profile | default("default") }}
 region: {{ var.region | default("us-east-1") }}
-template_bucket_name: "bootstrap-awss3cloudformationbucket-114n2ojlbvj21"
+#template_bucket_name: "bootstrap-awss3cloudformationbucket-114n2ojlbvj21"
 template_key_prefix: {{ environment_variable.TRAVIS_BRANCH | default("testing") }}
 admincentral_cf_bucket: "bootstrap-awss3cloudformationbucket-19qromfd235z9"

--- a/templates/gitlab-runner.yaml
+++ b/templates/gitlab-runner.yaml
@@ -95,8 +95,6 @@ Resources:
               - 'sts:AssumeRole'
       Path: /
       ManagedPolicyArns:
-        - !ImportValue
-          'Fn::Sub': '${AWS::Region}-essentials-TagRootVolumePolicy'
         - !Ref SsmManagedPolicy
         - !Ref KmsDecryptManagedPolicy
         - 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore'


### PR DESCRIPTION
Minor refactoring for new account

* sceptre will create a CFN bucket if one doesn't exist
* We don't need to tag volumes because new account is dedicated to one
  project so we remove TagRootVolumePolicy

both of the above changes makes it so that we don't need to create
reources in essentials.yaml[1] file for the new account.

[1] https://github.com/Sage-Bionetworks/aws-infra/blob/master/templates/essentials.yaml