### PR TITLE
IT-1301: Add Route53 zone for cri-iatlas

### DIFF
--- a/config/common/r53zone.yaml
+++ b/config/common/r53zone.yaml
@@ -1,0 +1,10 @@
+template_path: remote/R53-hostedzone.yaml
+stack_name: iatlas-dns-zone
+parameters:
+  Department: CompOnc
+  Project: iAtlas
+  OwnerEmail: andrew.lamb@sagebase.org
+  DnsDomainName: cri-iatlas.org
+hooks:
+  before_launch:
+    - !cmd "wget {{stack_group_config.aws_infra_templates_root_url}}/v0.2.20/templates/R53-hostedzone.yaml -O templates/remote/R53-hostedzone.yaml"


### PR DESCRIPTION
The DNS zone resides in the iAtlas account.
