### PR TITLE
Fix the SSO admin role ARN

### DIFF
--- a/config/prod/iatlas-kms.yaml
+++ b/config/prod/iatlas-kms.yaml
@@ -7,10 +7,10 @@ stack_tags:
 parameters:
   KeyAdminArns:
     - 'arn:aws:iam::386990716034:root'
-    - !rcmd aws iam get-role --role-name AWSReservedSSO_Administrator_13f4158c711c1d66  --query Role.Arn
+    - arn:aws:iam::386990716034:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_13f4158c711c1d66
     - !stack_output_external iatlas-prod-ci-access::ServiceRoleArn
     - !stack_output_external iatlas-collaborator-access::ServiceRoleArn
   KeyUserArns:
-    - !rcmd aws iam get-role --role-name AWSReservedSSO_Administrator_13f4158c711c1d66  --query Role.Arn
+    - arn:aws:iam::386990716034:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_13f4158c711c1d66
     - !stack_output_external iatlas-prod-ci-access::ServiceRoleArn
     - !stack_output_external iatlas-collaborator-access::ServiceRoleArn

--- a/config/staging/iatlas-kms.yaml
+++ b/config/staging/iatlas-kms.yaml
@@ -7,10 +7,10 @@ stack_tags:
 parameters:
   KeyAdminArns:
     - 'arn:aws:iam::386990716034:root'
-    - !rcmd aws iam get-role --role-name AWSReservedSSO_Administrator_13f4158c711c1d66  --query Role.Arn
+    - arn:aws:iam::386990716034:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_13f4158c711c1d66
     - !stack_output_external iatlas-prod-ci-access::ServiceRoleArn
     - !stack_output_external iatlas-collaborator-access::ServiceRoleArn
   KeyUserArns:
-    - !rcmd aws iam get-role --role-name AWSReservedSSO_Administrator_13f4158c711c1d66  --query Role.Arn
+    - arn:aws:iam::386990716034:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_13f4158c711c1d66
     - !stack_output_external iatlas-prod-ci-access::ServiceRoleArn
     - !stack_output_external iatlas-collaborator-access::ServiceRoleArn


### PR DESCRIPTION
The `!rcmd` resolver has a bug in it where it doesn't get the correct
AWS profile to run the command.  instead of doing a lookup we just
pass the ARN in as a static string.