### PR TITLE
refactor: replace hooks with template handler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - wget https://github.com/Sage-Bionetworks/infra-utils/archive/master.zip -O /tmp/infra-utils.zip
   - unzip -j -n /tmp/infra-utils.zip -x "infra-utils-master/.gitignore" "infra-utils-master/LICENSE" "infra-utils-master/*.md" "infra-utils-master/aws/*"
   - ./setup_aws_cli.sh || travis_terminate 1
-  - pip install pre-commit git+https://github.com/Sceptre/sceptre.git@5c0ab39 sceptre-ssm-resolver sceptre-ssm-resolver
+  - pip install pre-commit git+https://github.com/Sceptre/sceptre.git@5c0ab39 sceptre-ssm-resolver
 stages:
   - name: validate
   - name: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - wget https://github.com/Sage-Bionetworks/infra-utils/archive/master.zip -O /tmp/infra-utils.zip
   - unzip -j -n /tmp/infra-utils.zip -x "infra-utils-master/.gitignore" "infra-utils-master/LICENSE" "infra-utils-master/*.md" "infra-utils-master/aws/*"
   - ./setup_aws_cli.sh || travis_terminate 1
-  - pip install pre-commit sceptre sceptre-ssm-resolver
+  - pip install pre-commit git+https://github.com/Sceptre/sceptre.git@5c0ab39 sceptre-ssm-resolver sceptre-ssm-resolver
 stages:
   - name: validate
   - name: deploy

--- a/config/common/iatlasvpc.yaml
+++ b/config/common/iatlasvpc.yaml
@@ -1,4 +1,6 @@
-template_path: remote/vpc-mini.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.2/VPC/vpc-mini.yaml
 stack_name: iatlasvpc
 stack_tags:
   Department: "CompOnc"
@@ -7,6 +9,3 @@ stack_tags:
 parameters:
   VpcSubnetPrefix: "10.255.20"
   VpcName: iatlasvpc
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/VPC/vpc-mini.yaml --create-dirs -o templates/remote/vpc-mini.yaml"

--- a/config/common/r53zone.yaml
+++ b/config/common/r53zone.yaml
@@ -1,10 +1,9 @@
-template_path: remote/R53-hostedzone.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.20/R53-hostedzone.yaml
 stack_name: iatlas-dns-zone
 parameters:
   Department: CompOnc
   Project: iAtlas
   OwnerEmail: andrew.lamb@sagebase.org
   DnsDomainName: cri-iatlas.org
-hooks:
-  before_launch:
-    - !cmd "wget {{stack_group_config.aws_infra_templates_root_url}}/v0.2.20/templates/R53-hostedzone.yaml -O templates/remote/R53-hostedzone.yaml"

--- a/config/prod/iatlas-db.yaml
+++ b/config/prod/iatlas-db.yaml
@@ -1,4 +1,5 @@
-template_path: aurora-postgresql-db.yaml
+template:
+  path: aurora-postgresql-db.yaml
 stack_name: iatlasdb-prod
 dependencies:
   - common/iatlasvpc.yaml

--- a/config/prod/iatlas-kms.yaml
+++ b/config/prod/iatlas-kms.yaml
@@ -1,4 +1,5 @@
-template_path: kms.yaml
+template:
+  path: kms.yaml
 stack_name: iatlas-kms-prod
 stack_tags:
   Department: "CompOnc"

--- a/config/prod/iatlas-runner.yaml
+++ b/config/prod/iatlas-runner.yaml
@@ -1,4 +1,5 @@
-template_path: gitlab-runner.yaml
+template:
+  path: gitlab-runner.yaml
 stack_name: iatlas-gitlab-runner-prod
 dependencies:
   - common/iatlasvpc.yaml

--- a/config/staging/iatlas-db.yaml
+++ b/config/staging/iatlas-db.yaml
@@ -1,4 +1,5 @@
-template_path: aurora-postgresql-db.yaml
+template:
+  path: aurora-postgresql-db.yaml
 stack_name: iatlasdb-staging
 dependencies:
   - common/iatlasvpc.yaml

--- a/config/staging/iatlas-kms.yaml
+++ b/config/staging/iatlas-kms.yaml
@@ -1,4 +1,5 @@
-template_path: kms.yaml
+template:
+  path: kms.yaml
 stack_name: iatlas-kms-staging
 stack_tags:
   Department: "CompOnc"

--- a/config/staging/iatlas-runner.yaml
+++ b/config/staging/iatlas-runner.yaml
@@ -1,4 +1,5 @@
-template_path: gitlab-runner.yaml
+template:
+  path: gitlab-runner.yaml
 stack_name: iatlas-gitlab-runner-staging
 dependencies:
   - common/iatlasvpc.yaml


### PR DESCRIPTION
Sceptre has template handlers[1] now so we can abandon the use of
hooks in favor of the http template handler to get templates
from our shared template repository.

[1] https://sceptre.cloudreach.com/dev/docs/template_handlers.html#template-handlers
