### PR TITLE
Deploy with service user

### DIFF
--- a/config/prod/iatlas-kms.yaml
+++ b/config/prod/iatlas-kms.yaml
@@ -10,10 +10,10 @@ parameters:
     - 'arn:aws:iam::386990716034:root'
     - arn:aws:iam::386990716034:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_13f4158c711c1d66
     - !stack_output_external iatlas-prod-ci-access::ServiceRoleArn
-    - !stack_output_external iatlas-collaborator-access::ServiceRoleArn
+    - !stack_output_external iatlas-prod-ci-access::ServiceRoleArn
   KeyUserArns:
     - arn:aws:iam::386990716034:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_13f4158c711c1d66
     - !stack_output_external iatlas-prod-ci-access::ServiceRoleArn
-    - !stack_output_external iatlas-collaborator-access::ServiceRoleArn
+    - !stack_output_external iatlas-prod-ci-access::ServiceRoleArn
     - !stack_output_external iatlas-gitlab-roles-prod::RunnersRoleArn
     - !stack_output_external iatlas-api-roles-prod::ExecutionRoleArn

--- a/config/staging/iatlas-kms.yaml
+++ b/config/staging/iatlas-kms.yaml
@@ -10,10 +10,10 @@ parameters:
     - 'arn:aws:iam::386990716034:root'
     - arn:aws:iam::386990716034:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_13f4158c711c1d66
     - !stack_output_external iatlas-prod-ci-access::ServiceRoleArn
-    - !stack_output_external iatlas-collaborator-access::ServiceRoleArn
+    - !stack_output_external iatlas-prod-ci-access::ServiceRoleArn
   KeyUserArns:
     - arn:aws:iam::386990716034:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_13f4158c711c1d66
     - !stack_output_external iatlas-prod-ci-access::ServiceRoleArn
-    - !stack_output_external iatlas-collaborator-access::ServiceRoleArn
+    - !stack_output_external iatlas-prod-ci-access::ServiceRoleArn
     - !stack_output_external iatlas-gitlab-roles-staging::RunnersRoleArn
     - !stack_output_external iatlas-api-roles-staging::ExecutionRoleArn


### PR DESCRIPTION
The CI is setup to deploy using the collaborator's aws user/role.

IT removed the collaborator's access to the AWS account in PR https://github.com/Sage-Bionetworks-IT/organizations-infra/pull/407
Therefore it now fails to run deployments.

We don't want the CI to use the colloborator's user/role to deploy
resources to AWS.  Instead we want to use the service user/role to
do the deployment.  This PR switches to using the service user
to deploy to AWS.

