### PR TITLE
IT-2011: Remove runner imageId param

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -11,7 +11,11 @@ gitlab_container_user: {{ environment_variable.GITLAB_CONTAINER_USER | default('
 # DO NOT store the token in git.
 gitlab_reg_token: {{ environment_variable.GITLAB_REG_TOKEN | default('_NEVER_GONNA_GET_IT_') }}
 gitlab_runner_instance_type_prod: 'r5a.2xlarge'
+# This should get recommended one:
+# aws ssm get-parameters --names /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id --region us-east-1
 gitlab_runner_instance_type_staging: 'r5a.2xlarge'
+gitlab_manager_ami_id_prod: 'ami-03f8a7b55051ae0d4'
+gitlab_manager_ami_id_staging: 'ami-03f8a7b55051ae0d4'
 ecs_cluster_name_prod: 'iatlas-prod-EcsCluster'
 ecs_service_name_prod: 'iatlas-prod-EcsService'
 ecs_cluster_name_staging: 'iatlas-staging-EcsCluster'

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -12,8 +12,6 @@ gitlab_container_user: {{ environment_variable.GITLAB_CONTAINER_USER | default('
 gitlab_reg_token: {{ environment_variable.GITLAB_REG_TOKEN | default('_NEVER_GONNA_GET_IT_') }}
 gitlab_runner_instance_type_prod: 'r5a.2xlarge'
 gitlab_runner_instance_type_staging: 'r5a.2xlarge'
-gitlab_runner_instance_ami_id_prod: 'ami-08d4ac5b634553e16'
-gitlab_runner_instance_ami_id_staging: 'ami-08d4ac5b634553e16'
 ecs_cluster_name_prod: 'iatlas-prod-EcsCluster'
 ecs_service_name_prod: 'iatlas-prod-EcsService'
 ecs_cluster_name_staging: 'iatlas-staging-EcsCluster'

--- a/config/prod/iatlas-runner.yaml
+++ b/config/prod/iatlas-runner.yaml
@@ -20,6 +20,7 @@ parameters:
   GitLabRegToken: {{stack_group_config.gitlab_reg_token}}
   GitLabRunnerInstanceType: {{stack_group_config.gitlab_runner_instance_type_prod}}
   GitLabRunnerTag: 'prod'
+  ManagerImageId: {{stack_group_config.gitlab_manager_ami_id_prod}}
   CacheBucket: !stack_output_external iatlas-gitlab-s3-bucket-prod::CacheBucket
   ManagerRole: !stack_output_external iatlas-gitlab-roles-prod::ManagerRole
   RunnersRole: !stack_output_external iatlas-gitlab-roles-prod::RunnersRole

--- a/config/prod/iatlas-runner.yaml
+++ b/config/prod/iatlas-runner.yaml
@@ -19,7 +19,6 @@ parameters:
   DBAccessSecurityGroupName: !stack_output_external iatlasdb-prod::DBAccessSecurityGroupName
   GitLabRegToken: {{stack_group_config.gitlab_reg_token}}
   GitLabRunnerInstanceType: {{stack_group_config.gitlab_runner_instance_type_prod}}
-  GitLabRunnerInstanceAmiId: {{stack_group_config.gitlab_runner_instance_ami_id_prod}}
   GitLabRunnerTag: 'prod'
   CacheBucket: !stack_output_external iatlas-gitlab-s3-bucket-prod::CacheBucket
   ManagerRole: !stack_output_external iatlas-gitlab-roles-prod::ManagerRole

--- a/config/staging/iatlas-runner.yaml
+++ b/config/staging/iatlas-runner.yaml
@@ -20,7 +20,6 @@ parameters:
   DBAccessSecurityGroupName: !stack_output_external iatlasdb-staging::DBAccessSecurityGroupName
   GitLabRegToken: {{stack_group_config.gitlab_reg_token}}
   GitLabRunnerInstanceType: {{stack_group_config.gitlab_runner_instance_type_staging}}
-  GitLabRunnerInstanceAmiId: {{stack_group_config.gitlab_runner_instance_ami_id_staging}}
   GitLabRunnerTag: 'staging'
   CacheBucket: !stack_output_external iatlas-gitlab-s3-bucket-staging::CacheBucket
   ManagerRole: !stack_output_external iatlas-gitlab-roles-staging::ManagerRole

--- a/config/staging/iatlas-runner.yaml
+++ b/config/staging/iatlas-runner.yaml
@@ -21,6 +21,7 @@ parameters:
   GitLabRegToken: {{stack_group_config.gitlab_reg_token}}
   GitLabRunnerInstanceType: {{stack_group_config.gitlab_runner_instance_type_staging}}
   GitLabRunnerTag: 'staging'
+  ManagerImageId: {{stack_group_config.gitlab_manager_ami_id_staging}}
   CacheBucket: !stack_output_external iatlas-gitlab-s3-bucket-staging::CacheBucket
   ManagerRole: !stack_output_external iatlas-gitlab-roles-staging::ManagerRole
   RunnersRole: !stack_output_external iatlas-gitlab-roles-staging::RunnersRole

--- a/templates/gitlab-manager-runner.yaml
+++ b/templates/gitlab-manager-runner.yaml
@@ -8,7 +8,6 @@ Metadata:
         Parameters:
           - 'ManagerImageId'
           - 'ManagerInstanceType'
-          - 'GitLabRunnerInstanceAmiId'
           - 'GitLabRunnerInstanceType'
           - 'MinNumInstances'
           - 'MaxNumInstances'
@@ -69,9 +68,6 @@ Parameters:
     Type: 'String'
     MinLength: '29'
     MaxLength: '29'
-  GitLabRunnerInstanceAmiId:
-    Type: 'String'
-    Description: AMI Id to use for a Gitlab Runner
   GitLabRunnerInstanceType:
     Type: 'String'
     Description: Instance type for GitLab Runners.
@@ -296,7 +292,7 @@ Resources:
                       MachineDriver = "amazonec2"
                       MachineName = "gitlab-docker-machine-%s"
                       MachineOptions = [
-                        "amazonec2-ami=${GitLabRunnerInstanceAmiId}",
+                        "amazonec2-ami=${ManagerImageId}",
                         "amazonec2-instance-type=${GitLabRunnerInstanceType}",
                         "amazonec2-region=${AWS::Region}",
                         "amazonec2-zone=a",

--- a/templates/gitlab-manager-runner.yaml
+++ b/templates/gitlab-manager-runner.yaml
@@ -292,7 +292,6 @@ Resources:
                       MachineDriver = "amazonec2"
                       MachineName = "gitlab-docker-machine-%s"
                       MachineOptions = [
-                        "amazonec2-ami=${ManagerImageId}",
                         "amazonec2-instance-type=${GitLabRunnerInstanceType}",
                         "amazonec2-region=${AWS::Region}",
                         "amazonec2-zone=a",

--- a/templates/gitlab-manager-runner.yaml
+++ b/templates/gitlab-manager-runner.yaml
@@ -35,9 +35,8 @@ Parameters:
   # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/retrieve-ecs-optimized_AMI.html
   # AMI will be and Amazon Linux 2 which should be very close to CentOs/RHEL.
   ManagerImageId:
-    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
-    Default: '/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id'
-    Description: A reference to the latest ECS Optimized AMI Id.
+    Type: AWS::EC2::Image::Id
+    Description: An ECS Optimized AMI Id.
   ManagerInstanceType:
     Type: 'String'
     Description: Instance type for GitLab Runners' manager.


### PR DESCRIPTION
This PR removes the AMIID setup for the runners, leaves picking up the latest for manager.
Goal is to see if the registration works. 
