### PR TITLE
Add amiID for runner + IT-2114

### DIFF
--- a/templates/gitlab-manager-runner-roles.yaml
+++ b/templates/gitlab-manager-runner-roles.yaml
@@ -186,6 +186,7 @@ Resources:
             Action:
               - 'sts:AssumeRole'
       ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
         - !Ref EcsPolicy
         - !Ref AccessSecretPolicyArn
 

--- a/templates/gitlab-manager-runner.yaml
+++ b/templates/gitlab-manager-runner.yaml
@@ -291,6 +291,7 @@ Resources:
                       MachineDriver = "amazonec2"
                       MachineName = "gitlab-docker-machine-%s"
                       MachineOptions = [
+                        "amazonec2-ami=${ManagerImageId}",
                         "amazonec2-instance-type=${GitLabRunnerInstanceType}",
                         "amazonec2-region=${AWS::Region}",
                         "amazonec2-zone=a",


### PR DESCRIPTION
This PR re-adds an amiID for the runner (else it starts on Ubuntu), also adds AmazonSSMManagedInstanceCore to the runner role so we can connect to the runner instance while it's running.
