### PR TITLE
patch/fix: Install the forked version of docker machine.

### DIFF
--- a/templates/gitlab-manager-runner.yaml
+++ b/templates/gitlab-manager-runner.yaml
@@ -227,6 +227,8 @@ Resources:
         Fn::Base64: !Sub |
           #!/bin/bash -xe
 
+          # The current manager AMI is Amazon Linux 2 AMD/x84
+
           yum update -y aws-cfn-bootstrap
           yum install -y aws-cfn-bootstrap
 
@@ -234,6 +236,11 @@ Resources:
           curl -L "https://packages.gitlab.com/install/repositories/runner/gitlab-runner/script.rpm.sh" | bash
 
           yum install -y docker gitlab-runner
+
+          # Install the GitLab forked version of Docker Machine. See https://docs.gitlab.com/runner/executors/docker_machine.html#install
+          curl -O "https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/releases/v0.16.2-gitlab.18/downloads/docker-machine-Linux-x86_64"
+          cp docker-machine-Linux-x86_64 /usr/local/bin/docker-machine
+          chmod +x /usr/local/bin/docker-machine
 
           # Install the files and packages from the metadata
           /opt/aws/bin/cfn-init --stack '${AWS::StackName}' --region '${AWS::Region}' --resource Manager --configsets default


### PR DESCRIPTION
PR Checklist:
[X] Describe and explain your intentions for this change
The runner manager is not starting instances. I believe this is related to Docker Machine. Docker Machine is deprecated in Docker, but GitLab has created a fork to use with the runner. Install the GitLab forked version of Docker Machine.

[X] Setup pre-commit and run the validators (info in README.md)
    To validate files run: `pre-commit run --all-files`
