### PR TITLE
IT-2011: Remove amiId for runner

### DIFF
--- a/templates/gitlab-manager-runner.yaml
+++ b/templates/gitlab-manager-runner.yaml
@@ -283,7 +283,6 @@ Resources:
                       MachineDriver = "amazonec2"
                       MachineName = "gitlab-docker-machine-%s"
                       MachineOptions = [
-                        "amazonec2-ami=${ManagerImageId}",
                         "amazonec2-instance-type=${GitLabRunnerInstanceType}",
                         "amazonec2-region=${AWS::Region}",
                         "amazonec2-zone=a",


### PR DESCRIPTION
Attempting to resolve manager not connecting to runner. We added this to the original script, pulling back to docker-machine can pick the AMI itself.