### PR TITLE
IT-2011: Set runner AMIID to Ubuntu22

### DIFF
--- a/templates/gitlab-manager-runner.yaml
+++ b/templates/gitlab-manager-runner.yaml
@@ -283,6 +283,7 @@ Resources:
                       MachineDriver = "amazonec2"
                       MachineName = "gitlab-docker-machine-%s"
                       MachineOptions = [
+                        "amazonec2-ami=ami-08c40ec9ead489470",
                         "amazonec2-instance-type=${GitLabRunnerInstanceType}",
                         "amazonec2-region=${AWS::Region}",
                         "amazonec2-zone=a",

--- a/templates/gitlab-manager-runner.yaml
+++ b/templates/gitlab-manager-runner.yaml
@@ -152,6 +152,10 @@ Parameters:
   RunnersInstanceProfile:
     Description: The Name of the Runners Instance Profile.
     Type: String
+  GitLabRunnerAmiId:
+    Description: The AMI Id for the runner instance (must be Ubuntu)
+    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
+    Default: '/aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id'
 
 Conditions:
   UseSpotInstances: !Equals ['Yes', 'Never']
@@ -283,7 +287,7 @@ Resources:
                       MachineDriver = "amazonec2"
                       MachineName = "gitlab-docker-machine-%s"
                       MachineOptions = [
-                        "amazonec2-ami=ami-08c40ec9ead489470",
+                        "amazonec2-ami=${GitLabRunnerAmiId}",
                         "amazonec2-instance-type=${GitLabRunnerInstanceType}",
                         "amazonec2-region=${AWS::Region}",
                         "amazonec2-zone=a",


### PR DESCRIPTION
This PR sets the runner amiId to Ubuntu22.04. The default runner AMI used by the manager was Ubuntu16.04, which caused the runner provisioning to fail.