### PR TITLE
Db instance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ jobs:
   include:
     - stage: validate
       script:
-        - pre-commit autoupdate
         - pre-commit run --all-files
     - stage: deploy
       script:

--- a/config/prod/iatlas-db.yaml
+++ b/config/prod/iatlas-db.yaml
@@ -10,5 +10,5 @@ parameters:
   KmsKey: !stack_output_external iatlas-kms-prod::KmsKey
   DbSecretPrefix: 'prod_'
   DbCredsName: 'iatlas_db_creds_encrypted_prod'
-  DBInstanceClass: 'db.t3.large'
+  DBInstanceClass: 'db.m6g.large'
   DBEngineVersion: '12.4'

--- a/config/staging/iatlas-db.yaml
+++ b/config/staging/iatlas-db.yaml
@@ -10,5 +10,5 @@ parameters:
   KmsKey: !stack_output_external iatlas-kms-staging::KmsKey
   DbSecretPrefix: 'staging_'
   DbCredsName: 'iatlas_db_creds_encrypted_staging'
-  DBInstanceClass: 'db.t3.large'
+  DBInstanceClass: 'db.m6g.large'
   DBEngineVersion: '12.4'

--- a/templates/aurora-postgresql-db.yaml
+++ b/templates/aurora-postgresql-db.yaml
@@ -27,6 +27,8 @@ Parameters:
       - db.t3.large
       - db.t3.medium
       - db.t3.small
+      - db.m6g.large
+      - db.r6g.large
   DBEngineVersion:
     Description: 'Database engine version'
     Type: String


### PR DESCRIPTION
PR Checklist:
[X] Describe and explain your intentions for this change
We are getting a "No space left on device" (psycopg2.errors.DiskFull) error.
I believe this is telling us that the current db.t3.large instance we are using for the Aurora Postgres RDS is not sufficient (see: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Managing.html#AuroraPostgreSQL.Managing.TempStorage).
I believe we need to change the config in staging (and then in prod) to update this: https://github.com/Sage-Bionetworks/iAtlas-infra/blob/staging/config/prod/iatlas-db.yaml#L13
We would also need to update the AllowedValues:
https://github.com/Sage-Bionetworks/iAtlas-infra/blob/staging/templates/aurora-postgresql-db.yaml#L25
I'm thinking we could move to a db.m6g.large instance. This should give us the processing and temporary storage we need.
The db.t3.large has a max of 16GiB of temporary storage. To get more temp storage, we need to change the instance type. Additionally, the db.t3.medium, db.t3.large, db.t4g.medium, and db.t4g.large don't have the Huge_pages parameter enabled for postgres whereas all other instances do.
Pricing-wise, the db.m6g.large is not much more expensive than the current instance. (See: https://instances.vantage.sh/rds/?selected=db.m6g.large,db.t3.large)

[X] Setup pre-commit and run the validators (info in README.md)
    To validate files run: `pre-commit run --all-files`
