### PR TITLE
Does not support m6g, using r6g.

### DIFF
--- a/config/prod/iatlas-db.yaml
+++ b/config/prod/iatlas-db.yaml
@@ -10,5 +10,5 @@ parameters:
   KmsKey: !stack_output_external iatlas-kms-prod::KmsKey
   DbSecretPrefix: 'prod_'
   DbCredsName: 'iatlas_db_creds_encrypted_prod'
-  DBInstanceClass: 'db.m6g.large'
+  DBInstanceClass: 'db.r6g.large'
   DBEngineVersion: '12.4'

--- a/config/staging/iatlas-db.yaml
+++ b/config/staging/iatlas-db.yaml
@@ -10,5 +10,5 @@ parameters:
   KmsKey: !stack_output_external iatlas-kms-staging::KmsKey
   DbSecretPrefix: 'staging_'
   DbCredsName: 'iatlas_db_creds_encrypted_staging'
-  DBInstanceClass: 'db.m6g.large'
+  DBInstanceClass: 'db.r6g.large'
   DBEngineVersion: '12.4'

--- a/templates/aurora-postgresql-db.yaml
+++ b/templates/aurora-postgresql-db.yaml
@@ -27,7 +27,6 @@ Parameters:
       - db.t3.large
       - db.t3.medium
       - db.t3.small
-      - db.m6g.large
       - db.r6g.large
   DBEngineVersion:
     Description: 'Database engine version'


### PR DESCRIPTION
PR Checklist:
[X] Describe and explain your intentions for this change
RDS does not support creating a DB instance with the following combination: DBInstanceClass=db.m6g.large
Using db.r6g.large

[X] Setup pre-commit and run the validators (info in README.md)
    To validate files run: `pre-commit run --all-files`
