### PR TITLE
Removed `r5a.8xlarge` option.

### DIFF
--- a/templates/gitlab-manager-runner.yaml
+++ b/templates/gitlab-manager-runner.yaml
@@ -82,7 +82,6 @@ Parameters:
       - 'r5a.xlarge'
       - 'r5a.2xlarge'
       - 'r5a.4xlarge'
-      - 'r5a.8xlarge'
     Default: 't3a.micro'
     ConstraintDescription: must be a valid EC2 instance type
   GitLabDockerImage:


### PR DESCRIPTION
PR Checklist:
[X] Describe and explain your intentions for this change
Removed `r5a.8xlarge` option.

[X] Setup pre-commit and run the validators (info in README.md)
    To validate files run: `pre-commit run --all-files`
