### PR TITLE
upgrade api instances to xlarge

### DIFF
--- a/config/prod/iatlas-api.yaml
+++ b/config/prod/iatlas-api.yaml
@@ -11,7 +11,7 @@ dependencies:
   - prod/iatlas-api-roles.yaml
 stack_tags: {{stack_group_config.stack_tags}}
 parameters:
-  InstanceType: 'r5.large'
+  InstanceType: 'r5.xlarge'
   GitLabContainerSecretName: 'gitlab_registry_creds_prod'
   GitLabContainerPass: {{stack_group_config.gitlab_container_pass}}
   GitLabContainerUser: {{stack_group_config.gitlab_container_user}}

--- a/config/staging/iatlas-api.yaml
+++ b/config/staging/iatlas-api.yaml
@@ -11,7 +11,7 @@ dependencies:
   - staging/iatlas-api-roles.yaml
 stack_tags: {{stack_group_config.stack_tags}}
 parameters:
-  InstanceType: 'r5.large'
+  InstanceType: 'r5.xlarge'
   GitLabContainerSecretName: 'gitlab_registry_creds_staging'
   GitLabContainerPass: {{stack_group_config.gitlab_container_pass}}
   GitLabContainerUser: {{stack_group_config.gitlab_container_user}}

--- a/templates/ecs.yaml
+++ b/templates/ecs.yaml
@@ -69,6 +69,7 @@ Parameters:
       - t3a.medium
       - t3a.large
       - r5.large
+      - r5.xlarge
     ConstraintDescription: Please choose a valid instance type.
   DockerImageTag:
     Type: String


### PR DESCRIPTION
- Adds `r5.xlarge` to allowable instances sizes
- Changes API (prod and staging instnaces) to `r5.xlarge`
