### PR TITLE
Updated root size for runner to 100GB

### DIFF
--- a/templates/gitlab-manager-runner.yaml
+++ b/templates/gitlab-manager-runner.yaml
@@ -137,7 +137,7 @@ Parameters:
   RootSize:
     Type: Number
     Description: The root disk size of the runner instance (in GB).
-    Default: 24
+    Default: 100
   PrivateSubnetIds:
     Type: List<AWS::EC2::Subnet::Id>
     Description: Private subnet IDs from the VPC for the manager instance. Minimum of two.


### PR DESCRIPTION
PR Checklist:
[X] Describe and explain your intentions for this change
Downloaded files are much larger than 24 GB (at least 40GB) They get copied which makes at least 80GB. Updating to 100GB to give plenty of room for swap and growth.

[X] Setup pre-commit and run the validators (info in README.md)
    To validate files run: `pre-commit run --all-files`
