### PR TITLE
GitLab Runner repair

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -13,8 +13,9 @@ gitlab_runner_instance_type_prod: 'r5a.4xlarge'
 # This should get recommended one:
 # aws ssm get-parameters --names /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id --region us-east-1
 gitlab_runner_instance_type_staging: 'r5a.4xlarge'
-gitlab_manager_ami_id_prod: 'ami-03f8a7b55051ae0d4'
-gitlab_manager_ami_id_staging: 'ami-03f8a7b55051ae0d4'
+# AMI deprecation time: Sat Oct 03 2026 14:21:08 GMT-0700
+gitlab_manager_ami_id_prod: 'ami-04c6b54cfad330feb'
+gitlab_manager_ami_id_staging: 'ami-04c6b54cfad330feb'
 ecs_cluster_name_prod: 'iatlas-prod-EcsCluster'
 ecs_service_name_prod: 'iatlas-prod-EcsService'
 ecs_cluster_name_staging: 'iatlas-staging-EcsCluster'

--- a/templates/gitlab-manager-runner.yaml
+++ b/templates/gitlab-manager-runner.yaml
@@ -37,6 +37,8 @@ Parameters:
   ManagerImageId:
     Type: AWS::EC2::Image::Id
     Description: An ECS Optimized AMI Id.
+    # Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
+    # Default: '/aws/service/ecs/optimized-ami/amazon-linux-2/amzn2-ami-ecs-hvm-2.0.20241003-x86_64-ebs'
   ManagerInstanceType:
     Type: 'String'
     Description: Instance type for GitLab Runners' manager.
@@ -228,7 +230,7 @@ Resources:
           # Add the GitLab official repository to the package manager for CentOs/RHEL. See https://docs.gitlab.com/runner/install/linux-repository.html#installing-gitlab-runner.
           curl -L "https://packages.gitlab.com/install/repositories/runner/gitlab-runner/script.rpm.sh" | bash
 
-          yum install -y docker gitlab-runner
+          yum install -y docker gitlab-runner=15.9.0
 
           # Install the GitLab forked version of Docker Machine. See https://docs.gitlab.com/runner/executors/docker_machine.html#install
           curl -O "https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/releases/v0.16.2-gitlab.18/downloads/docker-machine-Linux-x86_64"


### PR DESCRIPTION
PR Checklist:
[X] Describe and explain your intentions for this change
There are changes to the Gitlab runner syntax.
(see: <https://docs.gitlab.com/ee/ci/runners/new_creation_workflow.html#changes-to-the-gitlab-runner-register-command-syntax>)
To ensure the runner can register, locking the version at 15.9.0.
Additionally, the AMI used for the GitLab Runner Manager is gone. Updated with a new one that deprecates in 2026. Also, added a comment noting the deprecation date of the AMI.

[X] Setup pre-commit and run the validators (info in README.md)
    To validate files run: `pre-commit run --all-files`
