### PR TITLE
Install `gitLab-runner` 5.9.0

### DIFF
--- a/templates/gitlab-manager-runner.yaml
+++ b/templates/gitlab-manager-runner.yaml
@@ -227,10 +227,13 @@ Resources:
           yum update -y aws-cfn-bootstrap
           yum install -y aws-cfn-bootstrap
 
-          # Add the GitLab official repository to the package manager for CentOs/RHEL. See https://docs.gitlab.com/runner/install/linux-repository.html#installing-gitlab-runner.
-          curl -L "https://packages.gitlab.com/install/repositories/runner/gitlab-runner/script.rpm.sh" | bash
+          # Add the GitLab official repository to the package manager for CentOs/RHEL. See https://docs.gitlab.com/runner/install/linux-repository.html#installing-gitlab-runner. Also see https://about.gitlab.com/blog/2022/05/02/amazon-linux-2-support-and-distro-specific-packages/.
+            curl -L "https://packages.gitlab.com/install/repositories/runner/gitlab-runner/script.rpm.sh" | bash
 
-          yum install -y docker gitlab-runner-15.9.0
+            # Patch to test or peg Amazon Linux 2 specific packages
+            sed -i "s/\/el\/7/\/amazon\/2/g" /etc/yum.repos.d/runner_gitlab*.repo
+
+            yum install -y docker gitlab-runner-15.9.0-1
 
           # Install the GitLab forked version of Docker Machine. See https://docs.gitlab.com/runner/executors/docker_machine.html#install
           curl -O "https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/releases/v0.16.2-gitlab.18/downloads/docker-machine-Linux-x86_64"

--- a/templates/gitlab-manager-runner.yaml
+++ b/templates/gitlab-manager-runner.yaml
@@ -230,7 +230,7 @@ Resources:
           # Add the GitLab official repository to the package manager for CentOs/RHEL. See https://docs.gitlab.com/runner/install/linux-repository.html#installing-gitlab-runner.
           curl -L "https://packages.gitlab.com/install/repositories/runner/gitlab-runner/script.rpm.sh" | bash
 
-          yum install -y docker gitlab-runner=15.9.0
+          yum install -y docker gitlab-runner-15.9.0
 
           # Install the GitLab forked version of Docker Machine. See https://docs.gitlab.com/runner/executors/docker_machine.html#install
           curl -O "https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/releases/v0.16.2-gitlab.18/downloads/docker-machine-Linux-x86_64"


### PR DESCRIPTION
PR Checklist:
[X] Describe and explain your intentions for this change
To install `gitlab-runner` with a specific version, the version MUST be designated with a dash "-" NOT an equal "=". See: [https://docs.gitlab.com/runner/install/linux-repository.html](https://docs.gitlab.com/runner/install/linux-repository.html?tab=RHEL%2FCentOS%2FFedora%2FAmazon+Linux)
Also see info on installing `gitlab-runner` specifically for Amazon Linux 2 instances: <https://about.gitlab.com/blog/2022/05/02/amazon-linux-2-support-and-distro-specific-packages/>

[X] Setup pre-commit and run the validators (info in README.md)
    To validate files run: `pre-commit run --all-files`
