### PR TITLE
Back to LaunchTemplate - needed to update the resource name for cfn-init.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,31 +24,19 @@ The `config.yaml` picks up a number of environment variables. All have defaults 
 
 - `GITLAB_CONTAINER_PASS`
 
-  This is the password (token) for accessing the GitLab container registry. These are generated and found in GitLab (the main CRI-iAtlas project) under `Settings->Repository->Deploy Tokens`. The scope should be "read_registry". See <https://gitlab.com/groups/cri-iatlas/-/settings/repository>
+  This is the password (token) for accessing the GitLab container registry. These are generated and found in GitLab (the main CRI-iAtlas project) under `Settings->Repository->Deploy Tokens`. The scope should be "read_registry". See <https://gitlab.com/groups/cri-iatlas/-/settings/repository#js-deploy-tokens>
 
 - `GITLAB_CONTAINER_USER`
 
-  This is the username for accessing the GitLab container registry. These are generated and found in GitLab (the main CRI-iAtlas project) under `Settings->Repository->Deploy Tokens`. The scope should be "read_registry". See <https://gitlab.com/groups/cri-iatlas/-/settings/repository>
+  This is the username for accessing the GitLab container registry. These are generated and found in GitLab (the main CRI-iAtlas project) under `Settings->Repository->Deploy Tokens`. The scope should be "read_registry". See <https://gitlab.com/groups/cri-iatlas/-/settings/repository#js-deploy-tokens>
 
 - `GITLAB_REG_TOKEN`
 
   This is the token for registering the Runner with GitLab. This is found in GitLab (the main CRI-iAtlas project) under `CI/CD->Runners->Register a group runner`. See <https://gitlab.com/groups/cri-iatlas/-/runners>
 
-### Secrets
-
-For the API to access the database the following secrets must be created in the [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/)
-
-- `iatlas_gitlab_registry_creds`
-
-  with values for:
-  - `username`
-  - `password`
-
-  These are readonly credentials for accessing the container registry in GitLab. The username and password (deploy token) are generated in [GitLab](https://gitlab.com/groups/cri-iatlas/-/settings/repository#js-deploy-tokens)
-
 ### Manual Deploys
 
-The following MUST be created initially for the CI/CD to work in GitLab:
+The following MUST be created initially:
 
 - `staging/iatlas-runner.yaml`
 
@@ -68,7 +56,7 @@ The following MUST be created initially for the CI/CD to work in GitLab:
 
 - `prod/iatlas-runner.yaml`
 
-  The `prod` GitLab runner is used for prod environment builds in GitLab only. Creating it will also create:
+  The `prod` GitLab runner is used for prod environment builds only. Creating it will also create:
   - `common/iatlasvpc.yaml`
   - `common/maintenance.yaml`
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -10,9 +10,9 @@ gitlab_container_user: {{ environment_variable.GITLAB_CONTAINER_USER | default('
 # DO NOT store the token in git.
 gitlab_reg_token: {{ environment_variable.GITLAB_REG_TOKEN | default('_NEVER_GONNA_GET_IT_') }}
 gitlab_runner_instance_type_prod: 'r5a.4xlarge'
-# This should get recommended one:
-# aws ssm get-parameters --names /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id --region us-east-1
 gitlab_runner_instance_type_staging: 'r5a.4xlarge'
+# This should get recommended ami_id:
+# aws ssm get-parameters --names /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id --region us-east-1
 # AMI deprecation time: Sat Oct 03 2026 14:21:08 GMT-0700
 gitlab_manager_ami_id_prod: 'ami-04c6b54cfad330feb'
 gitlab_manager_ami_id_staging: 'ami-04c6b54cfad330feb'

--- a/templates/gitlab-manager-runner.yaml
+++ b/templates/gitlab-manager-runner.yaml
@@ -186,7 +186,9 @@ Resources:
   RunnerAutoScalingGroup:
     Type: 'AWS::AutoScaling::AutoScalingGroup'
     Properties:
-      LaunchConfigurationName: !Ref ManagerLaunchConfig
+      LaunchTemplate:
+        LaunchTemplateId: !Ref ManagerLaunchTemplate
+        Version: !GetAtt ManagerLaunchTemplate.LatestVersionNumber
       VPCZoneIdentifier: !Ref PrivateSubnetIds
       MinSize: !Ref MinNumInstances
       MaxSize: !Ref MaxNumInstances
@@ -213,36 +215,44 @@ Resources:
   ########################
   ### Manager Instance ###
   ########################
-  ManagerLaunchConfig:
-    Type: 'AWS::AutoScaling::LaunchConfiguration'
+  ManagerLaunchTemplate:
+    Type: 'AWS::EC2::LaunchTemplate'
     Properties:
-      ImageId: !Ref 'ManagerImageId'
-      InstanceType: !Ref 'ManagerInstanceType'
-      IamInstanceProfile: !Ref 'ManagerInstanceProfile'
-      SecurityGroups:
-        - !Ref 'ManagerSecurityGroup'
-      UserData:
-        Fn::Base64: !Sub |
-          #!/bin/bash -xe
+      LaunchTemplateData:
+        IamInstanceProfile:
+          Name: !Ref 'ManagerInstanceProfile'
+        ImageId: !Ref 'ManagerImageId'
+        InstanceType: !Ref 'ManagerInstanceType'
+        SecurityGroupIds:
+          - !Ref 'ManagerSecurityGroup'
+        UserData:
+          Fn::Base64: !Sub |
+            #!/bin/bash -xe
 
-          # The current manager AMI is Amazon Linux 2 AMD/x84
+            # The current manager AMI is Amazon Linux 2 AMD/x84
 
-          yum update -y aws-cfn-bootstrap
-          yum install -y aws-cfn-bootstrap
+            yum update -y aws-cfn-bootstrap
+            yum install -y aws-cfn-bootstrap
 
-          # Add the GitLab official repository to the package manager for CentOs/RHEL. See https://docs.gitlab.com/runner/install/linux-repository.html#installing-gitlab-runner. Also see https://about.gitlab.com/blog/2022/05/02/amazon-linux-2-support-and-distro-specific-packages/.
-          curl -L "https://packages.gitlab.com/install/repositories/runner/gitlab-runner/script.rpm.sh" | bash
+            # Add the GitLab official repository to the package manager for CentOs/RHEL. See https://docs.gitlab.com/runner/install/linux-repository.html#installing-gitlab-runner. Also see https://about.gitlab.com/blog/2022/05/02/amazon-linux-2-support-and-distro-specific-packages/.
+            curl -L "https://packages.gitlab.com/install/repositories/runner/gitlab-runner/script.rpm.sh" | bash
 
-          # Patch to test or peg Amazon Linux 2 specific packages
-          sed -i "s/\/el\/7/\/amazon\/2/g" /etc/yum.repos.d/runner_gitlab*.repo
+            # Patch to test or peg Amazon Linux 2 specific packages
+            sed -i "s/\/el\/7/\/amazon\/2/g" /etc/yum.repos.d/runner_gitlab*.repo
 
-          yum install -y docker gitlab-runner-15.9.0-1
+            yum install -y docker gitlab-runner-15.9.0-1
 
-          # Install the files and packages from the metadata
-          /opt/aws/bin/cfn-init --stack '${AWS::StackName}' --region '${AWS::Region}' --resource Manager --configsets default
+            # Install the files and packages from the metadata
+            /opt/aws/bin/cfn-init --stack '${AWS::StackName}' --region '${AWS::Region}' --resource ManagerLaunchTemplate --configsets default
 
-          # Signal the status from cfn-init
-          /opt/aws/bin/cfn-signal -e $? --stack '${AWS::StackName}' --region '${AWS::Region}' --resource RunnerAutoScalingGroup
+            # Signal the status from cfn-init
+            /opt/aws/bin/cfn-signal -e $? --stack '${AWS::StackName}' --region '${AWS::Region}' --resource RunnerAutoScalingGroup
+      LaunchTemplateName: !Sub '${AWS::StackName}'
+      TagSpecifications:
+        - ResourceType: 'launch-template'
+          Tags:
+          - Key: 'Name'
+            Value: !Sub '${AWS::StackName}-CiRunner-Manager'
     Metadata:
       Comment: Register GitLab Runner
       'AWS::CloudFormation::Init':


### PR DESCRIPTION
PR Checklist:
[X] Describe and explain your intentions for this change
The LaunchTemplate was fine previously. The issue was in the `UserData`. The resource name passed to `/opt/aws/bin/cfn-init` needed to be updated to match the LaunchTemplate's resource name. Since it wasn't updated, the configset was never run and thus the cfn-init signal was never sent resulting in `Failed to receive 1 resource signal(s) for the current batch.  Each resource signal timeout is counted as a FAILURE.`

[X] Setup pre-commit and run the validators (info in README.md)
    To validate files run: `pre-commit run --all-files`
