### PR TITLE
Runner fix

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,12 @@
+You are a CloudFormation expert. You have expertise using Sceptre to deploy CloudFormation stacks.
+
+You are working on a project called "iAtlas Infra".
+
+iAtlas Infra is a project that manages the infrastructure for the iAtlas project. This includes the GitLab Runner, the ECS cluster, the ECS service, the RDS instance, the S3 bucket, and various other resources.
+
+Always use the latest syntax and features of Python and CloudFormation.
+Always follow best practices for Python and CloudFormation.
+
+You are also given the codebase and the relevant files.
+
+Your code should be clean, readable, maintainable, efficient, and DRY.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,21 @@ These resources are created by sceptre:
 
 - `config/prod` launches an aurora postgresql resource, kms key, and the api app for the production environment.
 
+## TODO
+
+- [ ] Update deprecated `docker-machine` to use `docker-autoscaler`.
+
+  See:
+  - <https://docs.gitlab.com/runner/executors/docker_autoscaler.html#examples>
+  - <https://gitlab.com/gitlab-org/fleeting/plugins/aws/-/tree/main>
+  - <https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-runnersautoscaler-section>
+
+- [ ] Update deprecated Gitlab registration token to the new runner registration workflow.
+
+  See:
+  - <https://docs.gitlab.com/ee/ci/runners/new_creation_workflow.html>
+  - <https://docs.gitlab.com/ee/ci/runners/new_creation_workflow.html#register-a-runner-with-a-project-token>
+
 ## Setup
 
 ### Environment Variables

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -13,9 +13,9 @@ gitlab_runner_instance_type_prod: 'r5a.4xlarge'
 gitlab_runner_instance_type_staging: 'r5a.4xlarge'
 # This should get recommended ami_id:
 # aws ssm get-parameters --names /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id --region us-east-1
-# AMI deprecation time: Sat Oct 03 2026 14:21:08 GMT-0700
-gitlab_manager_ami_id_prod: 'ami-04c6b54cfad330feb'
-gitlab_manager_ami_id_staging: 'ami-04c6b54cfad330feb'
+# AMI deprecation time: (2027-01-02T22:14:34.000Z) Sat Jan 02 2027 17:14:34 GMT-0500
+gitlab_manager_ami_id_prod: 'ami-00510a0be518b7bcf'
+gitlab_manager_ami_id_staging: 'ami-00510a0be518b7bcf'
 ecs_cluster_name_prod: 'iatlas-prod-EcsCluster'
 ecs_service_name_prod: 'iatlas-prod-EcsService'
 ecs_cluster_name_staging: 'iatlas-staging-EcsCluster'

--- a/templates/gitlab-manager-runner.yaml
+++ b/templates/gitlab-manager-runner.yaml
@@ -237,10 +237,15 @@ Resources:
             # Add the GitLab official repository to the package manager for CentOs/RHEL. See https://docs.gitlab.com/runner/install/linux-repository.html#installing-gitlab-runner. Also see https://about.gitlab.com/blog/2022/05/02/amazon-linux-2-support-and-distro-specific-packages/.
             curl -L "https://packages.gitlab.com/install/repositories/runner/gitlab-runner/script.rpm.sh" | bash
 
-            # Patch to test or peg Amazon Linux 2 specific packages
+            # Patch for Amazon Linux 2 specific packages
             sed -i "s/\/el\/7/\/amazon\/2/g" /etc/yum.repos.d/runner_gitlab*.repo
 
-            yum install -y docker gitlab-runner-15.9.0-1
+            # Registering the runner with a registration token was deprecated in 15.6 and will be removed in version 18.
+            # Docker-autoscaler is available as an experimental feature in version 15.11.0, beta in version 16.6, and generally available in version 17.1.
+            yum install -y docker gitlab-runner-17.1.0-1
+
+            # Install the GitLab forked version of Docker Machine. See https://docs.gitlab.com/runner/executors/docker_machine.html#install
+            curl -O "https://gitlab-docker-machine-downloads.s3.amazonaws.com/v0.16.2-gitlab.30/docker-machine-Linux-x86_64" && cp docker-machine-Linux-x86_64 /usr/local/bin/docker-machine && chmod +x /usr/local/bin/docker-machine
 
             # Install the files and packages from the metadata
             /opt/aws/bin/cfn-init --stack '${AWS::StackName}' --region '${AWS::Region}' --resource ManagerLaunchTemplate --configsets default
@@ -276,6 +281,7 @@ Resources:
               content: !Sub
                 - |
                   [[runners]]
+                    name = "gitlab-runner-${GitLabRunnerTag}"
                     limit = ${GitLabMaxConcurrentBuilds}
                     environment = [
                       "DB_HOST=${DbHost}",
@@ -283,6 +289,7 @@ Resources:
                       "DOCKER_DRIVER=overlay2",
                       "DOCKER_TLS_CERTDIR=/certs"
                     ]
+                    executor = "docker+machine"
                     [runners.docker]
                       tls_verify = false
                       image = "${GitLabDockerImage}"
@@ -346,16 +353,13 @@ Resources:
                 action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --region ${AWS::Region} --resource Manager --configsets default
                 runas=root
           commands:
-            10-docker-machine:
-              # Install the GitLab forked version of Docker Machine. See https://docs.gitlab.com/runner/executors/docker_machine.html#install
-              command: curl -O "https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/releases/v0.16.2-gitlab.18/downloads/docker-machine-Linux-x86_64" && cp docker-machine-Linux-x86_64 /usr/local/bin/docker-machine && chmod +x /usr/local/bin/docker-machine
-            20-register-runner:
+            10-register-runner:
               command: !Sub >-
                 gitlab-runner register --non-interactive --template-config /tmp/manager-config.template.toml --url ${GitLabUrl} --registration-token ${GitLabRegToken} --docker-image alpine:latest --executor docker+machine --name ${AWS::StackName} --tag-list "${GitLabRunnerTag}" --run-untagged=false --locked=false
-            30-update-config:
+            20-update-config:
               command: !Sub >-
                 sed -i 's/concurrent = 1/concurrent = ${GitLabMaxConcurrentBuilds}/' /etc/gitlab-runner/config.toml
-            40-gitlab-runner-restart:
+            30-gitlab-runner-restart:
               command: gitlab-runner restart
           services:
             sysvinit:


### PR DESCRIPTION
PR Checklist:
[X] Describe and explain your intentions for this change
- Update the version of `gitlab-runner` to 17.1.0 in preparation to migrate away from `docker-machine` to `docker-autoscaler`.
- Updated the Gitlab Manager AMI
- Updated when the forked `docker-machine` executable is installed.
- Updated the version of the forked `docker-machine`.
- Tested in GenUI AWS account with GenUI GitLab runners.

[X] Setup pre-commit and run the validators (info in README.md)
    To validate files run: `pre-commit run --all-files`
