### PR TITLE
[IT-4063] Enable access flags for S3 buckets

### DIFF
--- a/templates/gitlab-runner-s3-bucket.yaml
+++ b/templates/gitlab-runner-s3-bucket.yaml
@@ -15,6 +15,11 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
       Tags:
         - Key: Name
           Value: !Sub '${AWS::StackName}-${AWS::AccountId}-CiRunner'


### PR DESCRIPTION
Security hub says we should enable per bucket access flags when creating buckets to make sure they are private.


