### PR TITLE
increase runner size to 150G

### DIFF
--- a/templates/gitlab-manager-runner.yaml
+++ b/templates/gitlab-manager-runner.yaml
@@ -139,7 +139,7 @@ Parameters:
   RootSize:
     Type: Number
     Description: The root disk size of the runner instance (in GB).
-    Default: 100
+    Default: 150
   PrivateSubnetIds:
     Type: List<AWS::EC2::Subnet::Id>
     Description: Private subnet IDs from the VPC for the manager instance. Minimum of two.


### PR DESCRIPTION
Database build failing due to insufficient size. This increases the size from 100G to 150G.
