### PR TITLE
rename subnet group

### DIFF
--- a/templates/aurora-postgresql-db.yaml
+++ b/templates/aurora-postgresql-db.yaml
@@ -41,6 +41,7 @@ Parameters:
     MinValue: 1115
     MaxValue: 65535
 
+
 Resources:
   #############
   ### Roles ###
@@ -93,9 +94,10 @@ Resources:
       SourceSecurityGroupId: !Ref ClusterSecurityGroup
       Description: 'Self Reference'
   DBSubnetGroup:
-    Type: AWS::DocDB::DBSubnetGroup
+    Type: AWS::RDS::DBSubnetGroup
     Properties:
-      DBSubnetGroupDescription: !Ref 'AWS::StackName'
+      DBSubnetGroupDescription: !Sub '${AWS::StackName}-subnet'
+      DBSubnetGroupName: !Sub '${AWS::StackName}-subnet'
       SubnetIds:
         - !ImportValue
           'Fn::Sub': '${AWS::Region}-${VpcName}-PrivateSubnet'
@@ -115,9 +117,10 @@ Resources:
     Properties:
       Description: !Sub 'Aurora Parameter Group for ${AWS::StackName}'
       Family: aurora-postgresql12
-# Currently not changing parameters from default values
-# https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Reference.html#AuroraPostgreSQL.Reference.ParameterGroups
-#     Parameters:
+      Parameters:
+        temp_buffers: '256MB'
+        work_mem: '64MB'
+        maintenance_work_mem: '256MB'
 
   ###############
   ### Secrets ###


### PR DESCRIPTION
The previous update to increase the database size failed on deploy. This renames the subnet group
